### PR TITLE
Add nix-shell support

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> {} }: 
+pkgs.mkShell {
+  packages = with pkgs; [
+    python3
+    uv
+  ];
+
+  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (with pkgs; [
+    cairo
+  ]);
+  
+  shellHook = ''
+    unset PYTHONPATH
+    uv sync
+    . .venv/bin/activate
+  '';
+}


### PR DESCRIPTION
### Özet
Nix kullanıcılarının projeyi yerel ortamda kolayca çalıştırabilmesini sağlar.

### Kullanım
1. Geliştirme ortamına giriş yapmak için:
```bash
nix-shell
```
2. Projeyi `localhost:8000` adresinde çalıştırmak için:
```bash
mkdocs serve
```