### PR TITLE
Dağıtım rehberine bir takım düzenlemeler ve eklemeler.

### DIFF
--- a/src/rehberler/hangi_dagitim.md
+++ b/src/rehberler/hangi_dagitim.md
@@ -22,7 +22,7 @@ Proton tarafından desteklenen oyunlara göz atmak için: [ProtonDB](https://www
 
 !!! note
 
-    - XFS dosya sistemi varsayılan olarak geldiği için ayrı bir disk bölümüne dual boot yapmak zahmetlidir. Tek bir depolama diskine kurulması önerilir. Bölümlendirme yaparak kurmak için ilgili rehberlere göz atabilirsiniz.
+    XFS dosya sistemi varsayılan olarak geldiği için ayrı bir disk bölümüne dual boot yapmak zahmetlidir. Tek bir depolama diskine kurulması önerilir. Bölümlendirme yaparak kurmak için ilgili rehberlere göz atabilirsiniz.
 
 ## Modern ve stabil bir dağıtım arıyorum
 
@@ -39,7 +39,8 @@ Proton tarafından desteklenen oyunlara göz atmak için: [ProtonDB](https://www
     - RPM ve Flathub gibi üçüncü parti uygulama depoları aktif şekilde gelmez, kullanıcı tarafından isteğe bağlı olarak aktifleştirilmelidir. 
 
 ### Ultramarine Linux
-[Ultramarine Linux](https://ultramarine-linux.org), Fedora'nın lisans sorunları sebebiyle eksik gelen özelliklerinin (RPM, flathub, multimedya kodekleri vs.) aktif şekilde sunulduğu, kurulum sonrası doğrudan kullanıma hazır gelen kullanıcı dostu bir dağıtımdır. KDE, GNOME, Budgie, Xfce masaüstü ortamlarını destekler. CachyOS'in sunduğu performans odaklı olarak özelleştirilmiş linux çekirdeğini kurulum esnasında kullanıcıya bir seçenek olarak sunmaktadır. 
+
+[Ultramarine Linux](https://ultramarine-linux.org), Fedora'nın lisans sorunları sebebiyle eksik gelen özelliklerinin (RPM, flathub, multimedya kodekleri vs.) aktif şekilde sunulduğu, kurulum sonrası doğrudan kullanıma hazır gelen kullanıcı dostu bir dağıtımdır. KDE, GNOME, Budgie, Xfce masaüstü ortamlarını destekler. CachyOS'in sunduğu performans odaklı olarak özelleştirilmiş linux çekirdeğini kurulum esnasında kullanıcıya bir seçenek olarak sunmaktadır.
 
 ### Zorin OS
 
@@ -47,7 +48,7 @@ Proton tarafından desteklenen oyunlara göz atmak için: [ProtonDB](https://www
 
 !!! note
 
-    - Zorin OS, diğer Linux dağıtımlarından farklı olarak Pro sürümü sunuyor olsa da, ücretsiz sürümü, Pro sürümünden herhangi bir şekilde daha az kabiliyete sahip değildir. Pro sürümü sadece bazı "ek avantajlar" barındırmaktadır.
+    Zorin OS, diğer Linux dağıtımlarından farklı olarak Pro sürümü sunuyor olsa da, ücretsiz sürümü, Pro sürümünden herhangi bir şekilde daha az kabiliyete sahip değildir. Pro sürümü sadece bazı "ek avantajlar" barındırmaktadır.
 
 ### Ubuntu
 
@@ -55,12 +56,11 @@ Proton tarafından desteklenen oyunlara göz atmak için: [ProtonDB](https://www
 
 !!! note
 
-    - Canonical şirketinin tekelinde olan kapalı kaynak snap paketleri varsayılan olarak kurulu gelir.
+    Canonical şirketinin tekelinde olan kapalı kaynak snap paketleri varsayılan olarak kurulu gelir.
 
 ### Kubuntu
 
-[Kubuntu](https://kubuntu.org/), KDE masaüstünü kullanan resmi bir Ubuntu varyantıdır. Ubuntu'nun bütün avantajlarını özelleştirilebilir bir KDE masaüstünde size sunar. Arayüz benzerliği açısından Windows'dan gelenlere normal Ubuntu'dan daha mantıklı gelebilir. Discover mağazası sayesinde bütün deb, Snap ve Flatpak(varsayılan olarak yüklü gelmez) paketlerinizi tek grafik arayüzünden kolaylıkla yönetebilirsiniz. 
-    
+[Kubuntu](https://kubuntu.org/), KDE masaüstünü kullanan resmi bir Ubuntu varyantıdır. Ubuntu'nun bütün avantajlarını özelleştirilebilir bir KDE masaüstünde size sunar. Arayüz benzerliği açısından Windows'dan gelenlere normal Ubuntu'dan daha mantıklı gelebilir. Discover mağazası sayesinde bütün deb, Snap ve Flatpak(varsayılan olarak yüklü gelmez) paketlerinizi tek grafik arayüzünden kolaylıkla yönetebilirsiniz.
 
 ### Bluefin/Aurora
 
@@ -74,16 +74,17 @@ Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kuru
 
 !!! note
 
-    - COSMIC arayüzü yeni bir masaüstü ortamı olması nedeniyle hem özellikler bakımından henüz eksiktir hem de kullanım esnasında kararsızlıklar yaşanabilir. Ancak gelecekte GNOME ve KDE gibi temel masaüstü ortamlarına güçlü bir alternatif olma potansiyeli vardır.
+    COSMIC arayüzü yeni bir masaüstü ortamı olması nedeniyle hem özellikler bakımından henüz eksiktir hem de kullanım esnasında kararsızlıklar yaşanabilir. Ancak gelecekte GNOME ve KDE gibi temel masaüstü ortamlarına güçlü bir alternatif olma potansiyeli vardır.
 
+### Elementary OS
 
+[Elementary OS](https://elementary.io/) (elementary OS şeklinde de stilize edilir) Ubuntu LTS tabanlı bir Linux dağıtımıdır. Kendini macOS ve Windows'un "düşünülmüş, kapsamlı ve etik" bir alternatifi olarak tanıtır ve istediğini öde modeline sahiptir. İşletim sistemi, masaüstü ortamı (Pantheon olarak adlandırılır) ve beraberindeki uygulamalar elementary, Inc. tarafından geliştirilir ve sürdürülür.
 
 ## Sürekli güncel ve stabil bir dağıtım arıyorum
 
 ### openSUSE
 
 [openSUSE](https://www.opensuse.org/), openSUSE Projesi tarafından geliştirilen ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. İki ana varyasyonda sunulmaktadır: Tumbleweed (yukarı akışlı, güncel paketlere sahip bir sürüm dağıtımı) ve Leap (SUSE Linux Enterprise kaynaklı, kararlı bir sürüm dağıtımı). OpenQA sistemiyle bütün paketleri sunucularda test edildikten sonra kullanıcılara sunulur bu sayede sistemsel kararlılık sağlanır. Ayrıca snapper isimli sistem yedekleme aracı doğrudan OpenSUSE geliştiricileri tarafından geliştirilir. Snapper sayesinde kararsızlık yaratan bir güncelleme sonrasında sistemi geri almak çok basittir. Belli temel özellikler dışında çoğu özellik bir ön ayar olmadan gelmektedir, kullanıcılardan bunları kendisine göre ayarlaması beklenir. Ayrıca paket yönetimi diğer dağıtımlara göre daha karmaşık olabilir bu yüzden tecrübeli kullanıcıya hitap eder.
-    
 
 ### Solus
 
@@ -107,7 +108,7 @@ Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kuru
 
 ### Linux Mint
 
-[Linux Mint](https://linuxmint.com/), Ubuntu tabanlı, kullanıcı dostu bir Linux dağıtımıdır. Windows’tan geçenler için tasarımı tanıdık gelir; masaüstü ortamı olarak Cinnamon, MATE veya XFCE alternatifleri ile gelir. Kurulumdan sonra neredeyse her şey hazır gelir: medya codec’leri, ofis uygulamaları, sürücüler vs. Stabil, hafif ve “kur ve kullan” tarzı bir sistemdir. Yeni başlayanlar için çok uygundur ama deneyimli kullanıcıyı da yormaz.
+[Linux Mint](https://linuxmint.com/), Ubuntu tabanlı, kullanıcı dostu bir Linux dağıtımıdır. Windows’tan geçenler için tasarımı tanıdık gelir; masaüstü ortamı olarak Cinnamon, MATE veya XFCE alternatifleri ile gelir. Kurulumdan sonra neredeyse her şey hazır gelir: medya codec’leri, ofis uygulamaları, sürücüler vs. Stabil, hafif ve "kur ve kullan" tarzı bir sistemdir. Yeni başlayanlar için çok uygundur ama deneyimli kullanıcıyı da yormaz.
 
 ### MX Linux
 
@@ -137,7 +138,7 @@ Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kuru
 
 ### Arch Linux
 
-[Arch Linux](https://wiki.archlinux.org/title/Ana_sayfa), “KISS” (Keep It Simple, Stupid) prensibini benimseyen, tam anlamıyla kullanıcı merkeziyetçi, minimalist bir Linux dağıtımıdır. Amacı, kullanıcıya tam kontrol sağlamak ve sistemi sadece ihtiyaçlarına göre şekillendirme özgürlüğü vermektir. Yani, hazır paketler, GUI’li kurulum sihirbazları vermez — kurarsın, ayarlarsın, yönetirsin. Bu bazılarının “zor”, bazılarının ise “tam özgürlük” dediği bir deneyimdir.
+[Arch Linux](https://wiki.archlinux.org/title/Ana_sayfa), "KISS" (Keep It Simple, Stupid) prensibini benimseyen, tam anlamıyla kullanıcı merkeziyetçi, minimalist bir Linux dağıtımıdır. Amacı, kullanıcıya tam kontrol sağlamak ve sistemi sadece ihtiyaçlarına göre şekillendirme özgürlüğü vermektir. Yani, hazır paketler, GUI’li kurulum sihirbazları vermez — kurarsın, ayarlarsın, yönetirsin. Bu bazılarının "zor", bazılarının ise "tam özgürlük" dediği bir deneyimdir.
 
 ### NixOS
 
@@ -151,7 +152,7 @@ Diğer geleneksel Linux dağıtımlarından farklı olarak, NixOS’ta paket yö
 
 ### Void Linux
 
-[Void](https://voidlinux.org/), monolitik Linux çekirdeğine dayanan, bağımsız olarak geliştirilmiş, genel amaçlı bir işletim sistemidir. Kullanıcıların yazılımları hızlı bir şekilde yüklemelerine, güncellemelerine ve kaldırmalarına veya XBPS kaynak paketleri koleksiyonunun yardımıyla kaynaklardan doğrudan yazılım oluşturmalarına olanak tanıyan hibrit bir ikili/kaynak paket yönetim sistemine sahiptir. Dağıtımın diğer özellikleri arasında Raspberry Pi tek kartlı bilgisayarlar (hem armv6 hem de armv7) için destek, günlük güncellemelerle yuvarlanan sürüm modeli ve “runit” adlı yerel init sistemi bulunmaktadır.
+[Void](https://voidlinux.org/), monolitik Linux çekirdeğine dayanan, bağımsız olarak geliştirilmiş, genel amaçlı bir işletim sistemidir. Kullanıcıların yazılımları hızlı bir şekilde yüklemelerine, güncellemelerine ve kaldırmalarına veya XBPS kaynak paketleri koleksiyonunun yardımıyla kaynaklardan doğrudan yazılım oluşturmalarına olanak tanıyan hibrit bir ikili/kaynak paket yönetim sistemine sahiptir. Dağıtımın diğer özellikleri arasında Raspberry Pi tek kartlı bilgisayarlar (hem armv6 hem de armv7) için destek, günlük güncellemelerle yuvarlanan sürüm modeli ve "runit" adlı yerel init sistemi bulunmaktadır.
 
 ## Özel donanımlarım için bir dağıtım arıyorum
 

--- a/src/rehberler/hangi_dagitim.md
+++ b/src/rehberler/hangi_dagitim.md
@@ -10,17 +10,19 @@ Proton tarafından desteklenen oyunlara göz atmak için: [ProtonDB](https://www
 
 ### Bazzite
 
-[Bazzite](https://bazzite.gg/), Valve'ın SteamOS 3'üne benzer şekilde tasarlanmış Fedora tabanlı bir Linux dağıtımıdır. Steam Deck de dahil olmak üzere taşınabilir cihazlar ve masaüstü bilgisayarlar için destek sunar. Hem sıradan hem de ileri düzey Linux oyuncuları için sorunsuz bir kullanıma hazır deneyim sunmayı amaçlamaktadır.
-
-!!! note
-
-    Bazzite, Windows ve Arch Linux gibi dağıtımlarla karşılaştırıldığında bile bazı oyunlarda daha yüksek FPS sağlayabilmektedir. [(Kaynak)](https://youtu.be/u4a2pDMXLAE)
+[Bazzite](https://bazzite.gg/), Valve'ın SteamOS 3'üne benzer şekilde tasarlanmış Fedora tabanlı bir Linux dağıtımıdır. Steam Deck de dahil olmak üzere taşınabilir cihazlar ve masaüstü bilgisayarlar için destek sunar. Hem sıradan hem de ileri düzey Linux oyuncuları için sorunsuz bir kullanıma hazır deneyim sunmayı amaçlamaktadır. 
 
 ### Nobara
 
-[Nobara Project](https://nobaraproject.org/), Fedora Linux'un, kullanıcı dostu iyileştirmelerle değiştirilmiş bir sürümüdür. Fedora, güçlü bir iş istasyonu işletim sistemi olmakla birlikte, üçüncü taraf veya tescilli yazılımları içeren paketler genellikle temiz bir kurulumda yer almaz. Bu nedenle, özellikle "tıklayıp kullan" şeklinde çalışan tipik kullanıcılar, tarayıcı ve ofis belgeleri gibi temel işlevlerin ötesine geçmek istediklerinde, genellikle belgeleri araştırmak için fazladan zaman harcamak zorunda kalabilirler.
+[Nobara Project](https://nobaraproject.org/), Fedora dağıtımının kullanıcı dostu iyileştirmelerle değiştirilmiş bir sürümüdür. Fedora, kurumsal yapısı gereği ve lisans sorunları sebebiyle üçüncü parti veya tescilli yazılımları içeren paketlerle gelmez. Nobara, Fedora’da eksik olan ve oyunlar açısından önemli olan WINE bağımlılıkları, OBS Studio, GStreamer gibi kodek paketleri, NVIDIA sürücüleri ve çeşitli küçük paket düzeltmeleri ile birlikte gelir. NVIDIA kullanıcıları için özel ISO kurulum imajlarına sahiptir.
 
-Fedora’da eksik olan ve özellikle oyunlar açısından önemli olan bazı bileşenler arasında WINE bağımlılıkları, OBS Studio, GStreamer gibi üçüncü taraf codec paketleri, NVIDIA gibi üçüncü taraf sürücüler ve çeşitli küçük paket düzeltmeleri bulunmaktadır.
+### PikaOS
+
+[PikaOS](https://wiki.pika-os.com), Debian Sid tabanını kullanıp oyun/performans odaklı olarak özel derlenmiş paketler ve özel bir Linux çekirdeği kullanan bir dağıtımdır. GNOME, KDE, Hyperland, Niri ve Cosmic masaüstü ortamlarını destekler. Masaüstü ortamları yeni kullanıcıların kolay kullanımı için özelleştirilmiş şekilde gelir. Kurulum sonrasındaki yönlendirmeleriyle yeni Linux kullanıcılarının ihtiyaç duyacağı multimedya kodekleri, oyun paketleri, ihtiyaç duyulabilecek programlar gibi temel unsurları hızlıca kurmayı sağlar. Diğer oyun ve performans odaklı dağıtımlara nazaran daha stabil paketler tercih eder. NVIDIA kullanıcıları için özel ISO kurulum imajlarına sahiptir.
+
+!!! note
+
+    - XFS dosya sistemi varsayılan olarak geldiği için ayrı bir disk bölümüne dual boot yapmak zahmetlidir. Tek bir depolama diskine kurulması önerilir. Bölümlendirme yaparak kurmak için ilgili rehberlere göz atabilirsiniz.
 
 ## Modern ve stabil bir dağıtım arıyorum
 
@@ -33,6 +35,11 @@ Fedora’da eksik olan ve özellikle oyunlar açısından önemli olan bazı bil
     - Fedora, Ubuntu gibi dağıtımlara kıyasla daha temiz ve saf bir GNOME masaüstü ortamı deneyimi sağlar.
     - Çoğu stabil dağıtıma kıyasla yeni yazılımlar daha erken depolara eklenir.
     - Kapalı kaynak Snap yazılım deposu yerine topluluk tarafından çokça tercih edilen Flatpak ile gelir.
+    - Lisans sorunları sebebiyle multimedya kodekleri ve donanım kodekleri yüklü gelmez. Bunlar kullanıcı tarafından kurulmak zorundadır.
+    - RPM ve Flathub gibi üçüncü parti uygulama depoları aktif şekilde gelmez, kullanıcı tarafından isteğe bağlı olarak aktifleştirilmelidir. 
+
+### Ultramarine Linux
+[Ultramarine Linux](https://ultramarine-linux.org), Fedora'nın lisans sorunları sebebiyle eksik gelen özelliklerinin (RPM, flathub, multimedya kodekleri vs.) aktif şekilde sunulduğu, kurulum sonrası doğrudan kullanıma hazır gelen kullanıcı dostu bir dağıtımdır. KDE, GNOME, Budgie, Xfce masaüstü ortamlarını destekler. CachyOS'in sunduğu performans odaklı olarak özelleştirilmiş linux çekirdeğini kurulum esnasında kullanıcıya bir seçenek olarak sunmaktadır. 
 
 ### Zorin OS
 
@@ -40,41 +47,52 @@ Fedora’da eksik olan ve özellikle oyunlar açısından önemli olan bazı bil
 
 !!! note
 
-    Zorin OS, diğer Linux dağıtımlarından farklı olarak Pro sürümü sunuyor olsa da, ücretsiz sürümü, Pro sürümünden herhangi bir şekilde daha az kabiliyete sahip değildir. Pro sürümü sadece bazı "ek avantajlar" barındırmaktadır.
+    - Zorin OS, diğer Linux dağıtımlarından farklı olarak Pro sürümü sunuyor olsa da, ücretsiz sürümü, Pro sürümünden herhangi bir şekilde daha az kabiliyete sahip değildir. Pro sürümü sadece bazı "ek avantajlar" barındırmaktadır.
 
 ### Ubuntu
 
 [Ubuntu](https://ubuntu.com/), Linux tabanlı özgür ve ücretsiz bir işletim sistemidir. Bilgisayarlar, sunucular ve akıllı telefonlara yönelik olarak geliştirilmektedir. Ubuntu projesi Linux ve özgür yazılımın, bilgisayar kullanıcılarının günlük yaşamının bir parçası haline gelmesi amacıyla başlatılmış olup ilk kararlı masaüstü sürümü Ekim 2004'te yayınlanmıştır. Ubuntu'nun masaüstü sürümü günümüzde 40 milyonu aşkın kullanıcı sayısıyla dünyanın en yaygın kullanılan masaüstü Linux dağıtımı konumundadır.
 
+!!! note
+
+    - Canonical şirketinin tekelinde olan kapalı kaynak snap paketleri varsayılan olarak kurulu gelir.
+
 ### Kubuntu
 
-[Kubuntu](https://kubuntu.org/), KDE masaüstünü kullanan resmi bir Ubuntu varyantıdır. Ubuntu'nun bütün avantajlarını özelleştirilebilir bir KDE masaüstünde size sunar. Arayüz benzerliği açısından Windows'dan gelenlere normal Ubuntu'dan daha mantıklı gelebilir. Discover mağazası sayesinde bütün deb, Snap ve Flatpak(varsayılan olarak yüklü gelmez) paketlerinizi tek grafik arayüzünden kolaylıkla yönetebilirsiniz.
+[Kubuntu](https://kubuntu.org/), KDE masaüstünü kullanan resmi bir Ubuntu varyantıdır. Ubuntu'nun bütün avantajlarını özelleştirilebilir bir KDE masaüstünde size sunar. Arayüz benzerliği açısından Windows'dan gelenlere normal Ubuntu'dan daha mantıklı gelebilir. Discover mağazası sayesinde bütün deb, Snap ve Flatpak(varsayılan olarak yüklü gelmez) paketlerinizi tek grafik arayüzünden kolaylıkla yönetebilirsiniz. 
+    
 
 ### Bluefin/Aurora
 
-[Bluefin](https://projectbluefin.io/) ve [Aurora](https://getaurora.dev/), Bazzite'ın yapımcıları Universal Blue tarafından yapılan sırayla GNOME ve KDE masaüstünü kullanan Fedora tabanlı dağıtımlardır. Atomic yapısı sayesinde bozması neredeyse imkansızdır. Güncellemeler kolaylıkla yapılır, tek bir komutla da geri çevirilebilir. Bazzite gibi NVIDIA driverları yüklü gelir. Bluefin ve Aurora'da uygulamalar Bazaar mağazısından Flatpak olarak yüklenir, gerekli olduğu durumlarda rpm-ostree kullanılarak standart paketlere erişim sağlanılabilir.
+[Bluefin](https://projectbluefin.io/) ve [Aurora](https://getaurora.dev/), Bazzite'ın yapımcıları Universal Blue tarafından yapılan sırayla GNOME ve KDE masaüstünü kullanan Fedora tabanlı dağıtımlardır. Atomic yapısı sayesinde bozması neredeyse imkansızdır. Güncellemeler kolaylıkla yapılır, tek bir komutla da geri çevirilebilir. Bazzite gibi NVIDIA driverları yüklü gelir. Bluefin ve Aurora'da uygulamalar Bazaar mağazısından Flatpak olarak yüklenir, gerekli olduğu durumlarda ujust veya rpm-ostree komutları kullanılarak standart paketlere erişim sağlanılabilir.
 
 ### Pop!\_OS
 
-[Pop OS](https://system76.com/pop/) (Pop!\_OS olarak da stilize edilir), Ubuntu tabanlı, ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. Özelleştirilmiş bir GNOME masaüstü ortamı olan COSMIC ile birlikte gelir. Dağıtım, Amerikalı Linux bilgisayar üreticisi System76 tarafından geliştirilmiştir.
+[Pop OS](https://system76.com/pop/) (Pop!\_OS olarak da stilize edilir), Ubuntu tabanlı, ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. Yeni geliştirilmekte olan COSMIC masaüstü ortamı ile birlikte gelir. Dağıtım, Amerikalı Linux bilgisayar üreticisi System76 tarafından geliştirilmiştir.
 
 Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kurulu olarak sunulmak üzere geliştirilmiştir, ancak çoğu bilgisayara da indirip kurmak mümkündür.
 
-### Elementary OS
+!!! note
 
-[Elementary OS](https://elementary.io/) (elementary OS şeklinde de stilize edilir) Ubuntu LTS tabanlı bir Linux dağıtımıdır. Kendini macOS ve Windows'un "düşünülmüş, kapsamlı ve etik" bir alternatifi olarak tanıtır ve istediğini öde modeline sahiptir. İşletim sistemi, masaüstü ortamı (Pantheon olarak adlandırılır) ve beraberindeki uygulamalar elementary, Inc. tarafından geliştirilir ve sürdürülür.
+    - COSMIC arayüzü yeni bir masaüstü ortamı olması nedeniyle hem özellikler bakımından henüz eksiktir hem de kullanım esnasında kararsızlıklar yaşanabilir. Ancak gelecekte GNOME ve KDE gibi temel masaüstü ortamlarına güçlü bir alternatif olma potansiyeli vardır.
+
+
 
 ## Sürekli güncel ve stabil bir dağıtım arıyorum
 
 ### openSUSE
 
-[openSUSE](https://www.opensuse.org/), openSUSE Projesi tarafından geliştirilen ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. İki ana varyasyonda sunulmaktadır: Tumbleweed (yukarı akışlı bir sürüm dağıtımı) ve Leap (SUSE Linux Enterprise kaynaklı, kararlı bir sürüm dağıtımı)
+[openSUSE](https://www.opensuse.org/), openSUSE Projesi tarafından geliştirilen ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. İki ana varyasyonda sunulmaktadır: Tumbleweed (yukarı akışlı, güncel paketlere sahip bir sürüm dağıtımı) ve Leap (SUSE Linux Enterprise kaynaklı, kararlı bir sürüm dağıtımı). OpenQA sistemiyle bütün paketleri sunucularda test edildikten sonra kullanıcılara sunulur bu sayede sistemsel kararlılık sağlanır. Ayrıca snapper isimli sistem yedekleme aracı doğrudan OpenSUSE geliştiricileri tarafından geliştirilir. Snapper sayesinde kararsızlık yaratan bir güncelleme sonrasında sistemi geri almak çok basittir. 
+
+### Solus
+
+[Solus]([https://getsol.us/), Masaüstü kullanıcısı hedeflenerek geliştirilen bağımsız ve kullanıcı dostu bir topluluk dağıtımıdır. KDE, GNOME, Budgie ve XFCE masaüstü ortamlarını destekler. Kurulum sonrasında flathub deposu, medya ve donanım kodekleri, zram gibi son kullanıcının ihtiyaç duyacağı temel özellikler hazır bir şekilde gelir. Ayrıca tüm uygulamalar ve güncellemeler mağazadan yönetilebilir. Solus, Pardus/PiSi Linux'tan tanıdığımız PiSi paket yöneticisinin çatallanmış hali olan eopkg paket yöneticisini kullanır. Sistem güncellemeleri haftalık olarak verilir, kritik paketler ise daha uzun süre test edilerek sunulduğundan güncellik ve kararlılık dengesini hedefler. `eopkg history` özelliğiyle güncellemeler geri alınabilir.
 
 ## Sürekli güncel bir dağıtım arıyorum
 
 ### CachyOS
 
-[CachyOS](https://cachyos.org/), Arch Linux tabanlı bir Linux dağıtımıdır. Hız ve güvenlik optimizasyonlarına odaklanır – varsayılan Linux çekirdeği, BORE (Burst-Oriented Response Enhancer) zamanlayıcısı ile ileri seviyede optimize edilmiştir. Normal Proton'dan daha fazla özelliğe ve optimizasyona sabip olan Proton-CachyOS ile gelir. Masaüstü paketleri ise LTO, x86-64-v3 ve x86-64-v4, Zen 4 optimizasyonları, güvenlik bayrakları ve performans iyileştirmeleri ile derlenmiştir. Sunulan masaüstü ortamları ve pencere yöneticileri arasında KDE, GNOME, Xfce, i3wm, Wayfire, LXQt, OpenBox, Cinnamon, COSMIC, UKUI, LXDE, MATE, Budgie, Qtile, Hyprland ve Sway bulunmaktadır. CachyOS, hem grafiksel hem de komut satırı tabanlı yükleyicilerle birlikte gelir.
+[CachyOS](https://cachyos.org/), Arch Linux tabanlı bir Linux dağıtımıdır. Hız ve güvenlik optimizasyonlarına odaklanır – varsayılan Linux çekirdeği, BORE (Burst-Oriented Response Enhancer) zamanlayıcısı ile ileri seviyede optimize edilmiştir. Normal Proton'dan daha fazla özelliğe ve optimizasyona sabip olan Proton-CachyOS ile gelir. Masaüstü paketleri ise LTO, x86-64-v3 ve x86-64-v4, Zen 4 optimizasyonları, güvenlik bayrakları ve performans iyileştirmeleri ile derlenmiştir. Sunulan masaüstü ortamları ve pencere yöneticileri arasında KDE, GNOME, Xfce, i3wm, Wayfire, LXQt, OpenBox, Cinnamon, COSMIC, UKUI, LXDE, MATE, Budgie, Qtile, Hyprland ve Sway bulunmaktadır. CachyOS, hem grafiksel hem de komut satırı tabanlı yükleyicilerle birlikte gelir. Snapper özelliğine sahip olduğundan kararsız güncellemeleri geri alma imkânı sunar.
 
 ### EndeavourOS
 
@@ -102,7 +120,7 @@ Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kuru
 
 ### Q4OS
 
-[Q4OS](https://q4os.org/), klasik bir kullanıcı arayüzü (Trinity) ve basit araçlar sunar. Google Chrome, VirtualBox ve geliştirici araçları gibi karmaşık üçüncü taraf uygulamalar için kararlı API'ler sağlamak üzere tasarlanmış Debian tabanlı bir masaüstü Linux dağıtımıdır. Sistem, çok düşük donanım gereksinimleri nedeniyle sanal bulut ortamları için de çok kullanışlıdır.
+[Q4OS](https://q4os.org/), klasik bir kullanıcı arayüzü (Trinity) ve basit araçlar sunar. Google Chrome, VirtualBox ve geliştirici araçları gibi karmaşık üçüncü parti uygulamalar için kararlı API'ler sağlamak üzere tasarlanmış Debian tabanlı bir masaüstü Linux dağıtımıdır. Sistem, çok düşük donanım gereksinimleri nedeniyle sanal bulut ortamları için de çok kullanışlıdır.
 
 ### Puppy Linux
 

--- a/src/rehberler/hangi_dagitim.md
+++ b/src/rehberler/hangi_dagitim.md
@@ -10,7 +10,7 @@ Proton tarafından desteklenen oyunlara göz atmak için: [ProtonDB](https://www
 
 ### Bazzite
 
-[Bazzite](https://bazzite.gg/), Valve'ın SteamOS 3'üne benzer şekilde tasarlanmış Fedora tabanlı bir Linux dağıtımıdır. Steam Deck de dahil olmak üzere taşınabilir cihazlar ve masaüstü bilgisayarlar için destek sunar. Hem sıradan hem de ileri düzey Linux oyuncuları için sorunsuz bir kullanıma hazır deneyim sunmayı amaçlamaktadır. 
+[Bazzite](https://bazzite.gg/), Valve'ın SteamOS 3'üne benzer şekilde tasarlanmış Fedora tabanlı bir Linux dağıtımıdır. Steam Deck de dahil olmak üzere taşınabilir cihazlar ve masaüstü bilgisayarlar için destek sunar. Hem sıradan hem de ileri düzey Linux oyuncuları için sorunsuz bir kullanıma hazır deneyim sunmayı amaçlamaktadır. Yapısı gereği farklı türde donanımlar için farklı ISO kurulum imajına sahiptir, bunlar için dağıtımın websitesinde iyi bir yönlendirme mevcuttur.
 
 ### Nobara
 
@@ -70,7 +70,7 @@ Proton tarafından desteklenen oyunlara göz atmak için: [ProtonDB](https://www
 
 [Pop OS](https://system76.com/pop/) (Pop!\_OS olarak da stilize edilir), Ubuntu tabanlı, ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. Yeni geliştirilmekte olan COSMIC masaüstü ortamı ile birlikte gelir. Dağıtım, Amerikalı Linux bilgisayar üreticisi System76 tarafından geliştirilmiştir.
 
-Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kurulu olarak sunulmak üzere geliştirilmiştir, ancak çoğu bilgisayara da indirip kurmak mümkündür.
+Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kurulu olarak sunulmak üzere geliştirilmiştir, ancak çoğu bilgisayara da indirip kurmak mümkündür. NVIDIA kullanıcıları için özel ISO kurulum imajlarına sahiptir.
 
 !!! note
 
@@ -82,7 +82,8 @@ Pop!\_OS esas olarak System76 tarafından üretilen bilgisayarlara önceden kuru
 
 ### openSUSE
 
-[openSUSE](https://www.opensuse.org/), openSUSE Projesi tarafından geliştirilen ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. İki ana varyasyonda sunulmaktadır: Tumbleweed (yukarı akışlı, güncel paketlere sahip bir sürüm dağıtımı) ve Leap (SUSE Linux Enterprise kaynaklı, kararlı bir sürüm dağıtımı). OpenQA sistemiyle bütün paketleri sunucularda test edildikten sonra kullanıcılara sunulur bu sayede sistemsel kararlılık sağlanır. Ayrıca snapper isimli sistem yedekleme aracı doğrudan OpenSUSE geliştiricileri tarafından geliştirilir. Snapper sayesinde kararsızlık yaratan bir güncelleme sonrasında sistemi geri almak çok basittir. 
+[openSUSE](https://www.opensuse.org/), openSUSE Projesi tarafından geliştirilen ücretsiz ve açık kaynaklı bir Linux dağıtımıdır. İki ana varyasyonda sunulmaktadır: Tumbleweed (yukarı akışlı, güncel paketlere sahip bir sürüm dağıtımı) ve Leap (SUSE Linux Enterprise kaynaklı, kararlı bir sürüm dağıtımı). OpenQA sistemiyle bütün paketleri sunucularda test edildikten sonra kullanıcılara sunulur bu sayede sistemsel kararlılık sağlanır. Ayrıca snapper isimli sistem yedekleme aracı doğrudan OpenSUSE geliştiricileri tarafından geliştirilir. Snapper sayesinde kararsızlık yaratan bir güncelleme sonrasında sistemi geri almak çok basittir. Belli temel özellikler dışında çoğu özellik bir ön ayar olmadan gelmektedir, kullanıcılardan bunları kendisine göre ayarlaması beklenir. Ayrıca paket yönetimi diğer dağıtımlara göre daha karmaşık olabilir bu yüzden tecrübeli kullanıcıya hitap eder.
+    
 
 ### Solus
 


### PR DESCRIPTION
"Üçüncü taraf" ifadesi yazılım dünyasında daha yaygın kullanılan şekilde "üçüncü parti" olarak değiştirildi.

Bazzite'a ait not düzenli olarak benchmark testlerini güncellemek gerekebileceği için kaldırıldı.

Nobara'nın açıklaması sadeleştirildi.

Fedora'nın notlarına üçüncü parti depoları, medya kodekleri gibi eksik özelliklerle geldiği ve kullanıcı tarafından aktifleştirilebileceği bilgisi eklendi.

Pop!_OS'in COSMIC arayüzüne dair kararsızlıklar belirtildi.

OpenSUSE'nin kararlılığını sağlayan OpenQA sistemi ve snapper özelliğine dair bilgiler eklendi.

PikaOS, Ultramarine Linux, Solus gibi son kullanıcı odaklı dağıtımların tanıtımları eklendi.

ElementaryOS nispeten terk edilmiş bir dağıtım olması sebebiyle çıkartıldı.